### PR TITLE
Bump commons-beanutils from 1.9.2 to 1.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.2</version>
+            <version>1.9.4</version>
             <type>jar</type>
         </dependency>
 		


### PR DESCRIPTION
Bumps commons-beanutils from 1.9.2 to 1.9.4.

---
updated-dependencies:
- dependency-name: commons-beanutils:commons-beanutils dependency-type: direct:production ...